### PR TITLE
Add clickable link to .github/copilot-instructions in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ Each instruction file uses frontmatter to specify which files the instructions a
 2. Customize the instruction files as needed for your specific project requirements
 3. GitHub Copilot will use these instructions when generating code in files matching the patterns specified in each instruction's frontmatter
 
-The main `.github/copilot-instructions.md` file provides high-level guidance and references the specialized instruction files for deeper context.
+The main `[.github/copilot-instructions.md](.github/copilot-instructions.md)` file provides high-level guidance and references the specialized instruction files for deeper context.
 
 ## Technology Stack
 

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ Each instruction file uses frontmatter to specify which files the instructions a
 2. Customize the instruction files as needed for your specific project requirements
 3. GitHub Copilot will use these instructions when generating code in files matching the patterns specified in each instruction's frontmatter
 
-The main `[.github/copilot-instructions.md](.github/copilot-instructions.md)` file provides high-level guidance and references the specialized instruction files for deeper context.
+The main [.github/copilot-instructions.md](.github/copilot-instructions.md) file provides high-level guidance and references the specialized instruction files for deeper context.
 
 ## Technology Stack
 


### PR DESCRIPTION
Given that it is the top-level file for the instructions, I was
surprised to see it wasn't a clickable link. Its a minor thing,
but it triggered me :-)